### PR TITLE
[4.13] [ARO-4744] CARRY: Do not run platform validation on an ARO cluster

### DIFF
--- a/pkg/asset/installconfig/installconfig.go
+++ b/pkg/asset/installconfig/installconfig.go
@@ -191,6 +191,11 @@ func (a *InstallConfig) platformValidation() error {
 		return alibabacloud.Validate(client, a.Config)
 	}
 	if a.Config.Platform.Azure != nil {
+		if a.Config.Platform.Azure.IsARO() {
+			// ARO performs platform validation in the Resource Provider before
+			// the Installer is called
+			return nil
+		}
 		client, err := a.Azure.Client()
 		if err != nil {
 			return err


### PR DESCRIPTION
We do this validation in the frontend, we shouldn't call it here as well.