### PR TITLE
Send full certificate chain on Azure ClientCertificateCredentialOptions

### DIFF
--- a/pkg/asset/installconfig/azure/session.go
+++ b/pkg/asset/installconfig/azure/session.go
@@ -291,6 +291,7 @@ func newTokenCredentialFromCertificates(credentials *Credentials, cloudConfig cl
 		ClientOptions: azcore.ClientOptions{
 			Cloud: cloudConfig,
 		},
+		SendCertificateChain: true,
 	}
 
 	data, err := os.ReadFile(credentials.ClientCertificatePath)


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-11212](https://issues.redhat.com/browse/ARO-11212)

### What this PR does / why we need it:

When instantiating a new azidentity ClientCertificateCredential, enable the `SendCertificateChain` property to send the full certificate chain. This is required for e.g. using the ARO RP's first-party service principal for this client. 


### Test plan for issue:

As of now, this code path is unused in the ARO installer fork+wrapper. This code path will be utilized for the eventual implementation of workload identity cluster installations, during which we will temporarily use the RP FPSP credential for initial bootstrapping. 

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Will be tested as part of the wider MIWI effort



/cherrypick release-4.14-azure