### PR TITLE
OAPE-232: Remove GCPLabelsTags featuregate checks and references

### DIFF
--- a/data/data/install.openshift.io_installconfigs.yaml
+++ b/data/data/install.openshift.io_installconfigs.yaml
@@ -3288,9 +3288,7 @@ spec:
                     description: userLabels has additional keys and values that the
                       installer will add as labels to all resources that it creates
                       on GCP. Resources created by the cluster itself may not include
-                      these labels. This is a TechPreview feature and requires setting
-                      CustomNoUpgrade featureSet with GCPLabelsTags featureGate enabled
-                      or TechPreviewNoUpgrade featureSet to configure labels.
+                      these labels.
                     items:
                       description: UserLabel is a label to apply to GCP resources
                         created for the cluster.
@@ -3327,10 +3325,7 @@ spec:
                       installer will add as tags to all resources that it creates
                       on GCP. Resources created by the cluster itself may not include
                       these tags. Tag key and tag value should be the shortnames of
-                      the tag key and tag value resource. This is a TechPreview feature
-                      and requires setting CustomNoUpgrade featureSet with GCPLabelsTags
-                      featureGate enabled or TechPreviewNoUpgrade featureSet to configure
-                      tags.
+                      the tag key and tag value resource.
                     items:
                       description: UserTag is a tag to apply to GCP resources created
                         for the cluster.

--- a/pkg/types/gcp/platform.go
+++ b/pkg/types/gcp/platform.go
@@ -48,17 +48,13 @@ type Platform struct {
 
 	// userLabels has additional keys and values that the installer will add as
 	// labels to all resources that it creates on GCP. Resources created by the
-	// cluster itself may not include these labels. This is a TechPreview feature
-	// and requires setting CustomNoUpgrade featureSet with GCPLabelsTags featureGate
-	// enabled or TechPreviewNoUpgrade featureSet to configure labels.
+	// cluster itself may not include these labels.
 	UserLabels []UserLabel `json:"userLabels,omitempty"`
 
 	// userTags has additional keys and values that the installer will add as
 	// tags to all resources that it creates on GCP. Resources created by the
 	// cluster itself may not include these tags. Tag key and tag value should
-	// be the shortnames of the tag key and tag value resource. This is a TechPreview
-	// feature and requires setting CustomNoUpgrade featureSet with GCPLabelsTags
-	// featureGate enabled or TechPreviewNoUpgrade featureSet to configure tags.
+	// be the shortnames of the tag key and tag value resource.
 	UserTags []UserTag `json:"userTags,omitempty"`
 
 	// UserProvisionedDNS indicates if the customer is providing their own DNS solution in place of the default

--- a/pkg/types/gcp/validation/featuregates.go
+++ b/pkg/types/gcp/validation/featuregates.go
@@ -1,9 +1,6 @@
 package validation
 
 import (
-	"k8s.io/apimachinery/pkg/util/validation/field"
-
-	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/featuregates"
 )
@@ -11,17 +8,5 @@ import (
 // GatedFeatures determines all of the install config fields that should
 // be validated to ensure that the proper featuregate is enabled when the field is used.
 func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeature {
-	g := c.GCP
-	return []featuregates.GatedInstallConfigFeature{
-		{
-			FeatureGateName: configv1.FeatureGateGCPLabelsTags,
-			Condition:       len(g.UserLabels) > 0,
-			Field:           field.NewPath("platform", "gcp", "userLabels"),
-		},
-		{
-			FeatureGateName: configv1.FeatureGateGCPLabelsTags,
-			Condition:       len(g.UserTags) > 0,
-			Field:           field.NewPath("platform", "gcp", "userTags"),
-		},
-	}
+	return []featuregates.GatedInstallConfigFeature{}
 }

--- a/pkg/types/validation/featuregate_test.go
+++ b/pkg/types/validation/featuregate_test.go
@@ -7,7 +7,6 @@ import (
 
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/types"
-	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/vsphere"
 )
 
@@ -17,46 +16,6 @@ func TestFeatureGates(t *testing.T) {
 		installConfig *types.InstallConfig
 		expected      string
 	}{
-		{
-			name: "GCP UserTags is allowed with Feature Gates enabled",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.FeatureSet = v1.TechPreviewNoUpgrade
-				c.GCP = validGCPPlatform()
-				c.GCP.UserTags = []gcp.UserTag{{ParentID: "a", Key: "b", Value: "c"}}
-				return c
-			}(),
-		},
-		{
-			name: "GCP UserTags is not allowed without Feature Gates",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.GCP = validGCPPlatform()
-				c.GCP.UserTags = []gcp.UserTag{{ParentID: "a", Key: "b", Value: "c"}}
-				return c
-			}(),
-			expected: `^platform.gcp.userTags: Forbidden: this field is protected by the GCPLabelsTags feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,
-		},
-		{
-			name: "GCP UserLabels is allowed with Feature Gates enabled",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.FeatureSet = v1.TechPreviewNoUpgrade
-				c.GCP = validGCPPlatform()
-				c.GCP.UserLabels = []gcp.UserLabel{{Key: "a", Value: "b"}}
-				return c
-			}(),
-		},
-		{
-			name: "GCP UserLabels is not allowed without Feature Gates",
-			installConfig: func() *types.InstallConfig {
-				c := validInstallConfig()
-				c.GCP = validGCPPlatform()
-				c.GCP.UserLabels = []gcp.UserLabel{{Key: "a", Value: "b"}}
-				return c
-			}(),
-			expected: `^platform.gcp.userLabels: Forbidden: this field is protected by the GCPLabelsTags feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set$`,
-		},
 		{
 			name: "vSphere hosts is allowed with Feature Gates enabled",
 			installConfig: func() *types.InstallConfig {

--- a/pkg/types/validation/installconfig_test.go
+++ b/pkg/types/validation/installconfig_test.go
@@ -1066,6 +1066,8 @@ func TestValidateInstallConfig(t *testing.T) {
 				c.Platform = types.Platform{
 					GCP: validGCPPlatform(),
 				}
+				c.GCP.UserTags = []gcp.UserTag{{ParentID: "12345", Key: "key", Value: "val"}}
+				c.GCP.UserLabels = []gcp.UserLabel{{Key: "key", Value: "val"}}
 				return c
 			}(),
 		},


### PR DESCRIPTION
PR contains below commits
- Removes feature gates checks for configuring GCP labels and tags, as the feature is GA.

Required for https://github.com/openshift/api/pull/2372